### PR TITLE
Allow plusplus in for loops

### DIFF
--- a/__tests__/fixtures/block.js
+++ b/__tests__/fixtures/block.js
@@ -1,7 +1,8 @@
 export function test() {
   const returnValue = [];
   const reprs = [];
-  for (let i = 0; i < 10; i += 1) {
+
+  for (let i = 0; i < 10; i++) {
     if (i % 2 === 0) {
       returnValue.push(['odd', i]);
     }

--- a/rules/ecma/index.js
+++ b/rules/ecma/index.js
@@ -80,7 +80,7 @@ module.exports = {
     'no-magic-numbers': ['off', { ignore: [], ignoreArrayIndexes: true, enforceConst: true, detectObjects: false }],
     'no-negated-condition': 'off',
     'no-param-reassign': 'error',
-    'no-plusplus': 'error',
+    'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'no-restricted-properties': ['error'].concat(restrictedProperties),
     'no-restricted-syntax': ['error'].concat(restrictedSyntax),
     'no-script-url': 'error',


### PR DESCRIPTION
The previous rule would have me write `i += 1` instead of `i++` in for loops, which is really weird.